### PR TITLE
Improve /rename to be more user friendly

### DIFF
--- a/src/main/java/net/purelic/CGC/commands/map/RenameCommand.java
+++ b/src/main/java/net/purelic/CGC/commands/map/RenameCommand.java
@@ -15,6 +15,7 @@ import org.bukkit.GameMode;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
+import java.io.File;
 import java.util.regex.Pattern;
 
 public class RenameCommand implements CustomCommand {
@@ -27,12 +28,15 @@ public class RenameCommand implements CustomCommand {
         return mgr.commandBuilder("rename")
             .senderType(Player.class)
             .permission(Permission.isMapDev(true))
-            .argument(StringArgument.quoted("name"))
-            .argument(StringArgument.quoted("new"))
+            .argument(StringArgument.greedy("name"))
             .handler(context -> mgr.taskRecipe().begin(context).synchronous(c -> {
                 Player player = (Player) c.getSender();
-                String name = c.get("name");
-                String newName = c.get("new");
+                String newName = c.get("name");
+
+                if (player.getWorld() == Commons.getLobby()) {
+                    CommandUtils.sendErrorMessage(player, "Please join the map you want to rename!");
+                    return;
+                }
 
                 if (MapManager.hasMap(newName)) {
                     CommandUtils.sendErrorMessage(player, "A map named \"" + newName + "\" already exists!");
@@ -51,45 +55,36 @@ public class RenameCommand implements CustomCommand {
                     return;
                 }
 
-                if (MapManager.hasMap(name)) {
-                    if (MapManager.isPending(name)) {
-                        CommandUtils.sendErrorMessage(player, "Please wait, this map is currently being modified!");
-                        return;
-                    }
+                String currentName = player.getWorld().getName();
+                CustomMap map = MapManager.getMap(currentName);
 
-                    if (!MapManager.isDownloaded(name)) {
-                        CommandUtils.sendErrorMessage(player, "Map not downloaded! Use /download " + name);
-                        return;
-                    }
-
-                    CustomMap customMap = MapManager.getMap(name);
-
-                    if (customMap.hasUnsavedChanges()) {
-                        CommandUtils.sendErrorMessage(player, "That map has unsaved changes, please save your map before renaming!");
-                        return;
-                    }
-
-                    String mapName = customMap.getName();
-
-                    for (Player online : Bukkit.getOnlinePlayers()) {
-                        if (online.getWorld() == customMap.getWorld()) {
-                            online.teleport(Commons.getLobby().getSpawnLocation());
-                            online.setGameMode(GameMode.ADVENTURE);
-                        }
-                    }
-
-                    CommandUtils.broadcastAlertMessage("Renaming map \"" + mapName + "\"...");
-                    MapManager.setPending(mapName, true);
-                    MapUtils.copyMap(mapName, newName, false); // copy map
-                    MapUtils.saveDraft(newName, Commons.getOwnerId());
-                    MapUtils.deleteMap(Commons.getOwnerId(), mapName, false); // delete old map
-
-                    MapManager.renameMap(mapName, newName); // rename map
-                    MapManager.setPending(mapName, false);
-                    CommandUtils.broadcastSuccessMessage("Map \"" + mapName + "\" successfully renamed to \"" + newName + "\"!");
-                } else {
-                    CommandUtils.sendErrorMessage(player, "Can't find map \"" + name + "\"");
+                if (MapManager.isPending(currentName)) {
+                    CommandUtils.sendErrorMessage(player, "Please wait, this map is currently being modified!");
+                    return;
                 }
+
+                if (map.hasUnsavedChanges()) {
+                    CommandUtils.sendErrorMessage(player, "That map has unsaved changes, please save your map before renaming!");
+                    return;
+                }
+
+                for (Player online : Bukkit.getOnlinePlayers()) {
+                    if (online.getWorld() == map.getWorld()) {
+                        online.teleport(Commons.getLobby().getSpawnLocation());
+                        online.setGameMode(GameMode.ADVENTURE);
+                    }
+                }
+
+                CommandUtils.broadcastAlertMessage("Renaming map \"" + currentName + "\"...");
+                MapManager.setPending(currentName, true);
+                MapUtils.copyMap(currentName, newName, false); // copy map
+                new File(Commons.getRoot() + newName + "/uid.dat").delete();
+                MapUtils.saveDraft(newName, Commons.getOwnerId());
+                MapUtils.deleteMap(Commons.getOwnerId(), currentName, false); // delete old map
+
+                MapManager.renameMap(currentName, newName); // rename map
+                MapManager.setPending(currentName, false);
+                CommandUtils.broadcastSuccessMessage("Map \"" + currentName + "\" successfully renamed to \"" + newName + "\"!");
             }).execute());
     }
 


### PR DESCRIPTION
closes #2 

Primary change made was to make the player join the world they want to rename vs specifying the world to rename as a command argument. Players don't have to use quotations around the map names either which caused a lot of confusion.