### PR TITLE
Add apache commons dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,11 @@
             <version>1.0</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.9.0</version>
+        </dependency>
 <!--        <dependency>-->
 <!--            <groupId>com.sk89q.worldedit</groupId>-->
 <!--            <artifactId>worldedit-bukkit</artifactId>-->


### PR DESCRIPTION
https://github.com/PuRelic/CGC/blob/main/src/main/java/net/purelic/CGC/commands/map/CreateCommand.java#L69

Idk why this line started causing issues when it would build just fine without it hours ago. Could probably move this into the Commons plugin since FileUtils.java works fine over there in MapUtils.java